### PR TITLE
spm_import: fixes for UVs, vertex colors, materials

### DIFF
--- a/io_antractica_scene/spm_import.py
+++ b/io_antractica_scene/spm_import.py
@@ -171,7 +171,7 @@ def generateMeshBuffer(spm, vertices_count, indices_count,
     for face in bm.faces:
         for loop in face.loops:
             if read_vcolor:
-                loop[color_layer] = vertices_list[loop.vert.index][0]
+                loop[color_layer] = vertices_list[loop.vert.index][0] + [1]  # RGB -> RGBA
             if uv_one:
                 loop[uv_layer].uv = vertices_list[loop.vert.index][1][0:2]
             if uv_two:

--- a/io_antractica_scene/spm_import.py
+++ b/io_antractica_scene/spm_import.py
@@ -165,25 +165,17 @@ def generateMeshBuffer(spm, vertices_count, indices_count,
         color_layer = bm.loops.layers.color.new()
     if uv_one:
         uv_layer = bm.loops.layers.uv.new()
-#        tex_layer = bm.faces.layers.tex.new()
     if uv_two:
         uv_layer_two = bm.loops.layers.uv.new()
-#        tex_layer_two = bm.faces.layers.tex.new()
 
     for face in bm.faces:
-        if uv_one:
-            face[tex_layer].image = material_map[material_id][0]
-        if uv_two:
-            face[tex_layer_two].image = material_map[material_id][1]
         for loop in face.loops:
             if read_vcolor:
                 loop[color_layer] = vertices_list[loop.vert.index][0]
-            #if uv_one:
-                #loop[uv_layer].uv = (vertices_list[loop.vert.index][1][0],
-                    #vertices_list[loop.vert.index][1][1])
-            #if uv_two:
-                #loop[uv_layer_two].uv = (vertices_list[loop.vert.index][1][2],
-                    #vertices_list[loop.vert.index][1][3])
+            if uv_one:
+                loop[uv_layer].uv = vertices_list[loop.vert.index][1][0:2]
+            if uv_two:
+                loop[uv_layer_two].uv = vertices_list[loop.vert.index][1][2:4]
 
     bmesh.ops.remove_doubles(bm, verts = bm.verts)
     bm.to_mesh(mesh)

--- a/io_antractica_scene/spm_import.py
+++ b/io_antractica_scene/spm_import.py
@@ -194,7 +194,7 @@ def generateMeshBuffer(spm, vertices_count, indices_count,
 
     coll = bpy.context.view_layer.active_layer_collection.collection
     coll.objects.link(obj)
-              
+
     obj.select_set(True)
     bpy.context.view_layer.objects.active = obj
 
@@ -295,7 +295,7 @@ class SPM_Import_Operator(bpy.types.Operator, ImportHelper):
     bl_idname = ("screen.spm_import")
     bl_label = ("SPM Import")
     bl_options = {'UNDO'}
-    
+
     filename_ext = ".spm"
     filter_glob: bpy.props.StringProperty(default="*.spm", options={'HIDDEN'})
     extra_tex_path: bpy.props.StringProperty(name="Texture path",\


### PR DESCRIPTION
From our blender.chat talk.

For the material, I only made a Principled shader that shows the first texture. You'll have to upgrade `create_material` if you want to write one that shows the two textures overlayed. 