### PR TITLE
Fix exporter for Blender 2.80

### DIFF
--- a/io_antractica_scene/spm_export.py
+++ b/io_antractica_scene/spm_export.py
@@ -654,20 +654,18 @@ def writeSPMFile(filename, objects=[]):
                 vertex_list.append((vertices, nor_vec, vertex_color, all_uvs, each_joint_data))
 
             t1 = Triangle()
-            # Because of triangulated
+            for vertex in vertex_list:
+                t1.m_position.append(vertex[0])
+                t1.m_normal.append(vertex[1])
+                t1.m_color.append(vertex[2])
+                t1.m_all_uvs.append(vertex[3])
+                t1.m_all_joints_weights.append(vertex[4])
+            t1.m_texture_one = texture_one
+            t1.m_texture_two = texture_two
+            t1.m_texture_cmp = texture_cmp
+            t1.m_armature_name = arm.data.name if arm != None else "NULL"
+            t1.setHashString()
             if need_export_tangent:
-                assert(len(vertex_list) == 3)
-                for vertex in vertex_list:
-                    t1.m_position.append(vertex[0])
-                    t1.m_normal.append(vertex[1])
-                    t1.m_color.append(vertex[2])
-                    t1.m_all_uvs.append(vertex[3])
-                    t1.m_all_joints_weights.append(vertex[4])
-                t1.m_texture_one = texture_one
-                t1.m_texture_two = texture_two
-                t1.m_texture_cmp = texture_cmp
-                t1.m_armature_name = arm.data.name if arm != None else "NULL"
-                t1.setHashString()
                 if t1 in tangents_triangles_dict:
                     t1.m_tangent = tangents_triangles_dict[t1]
                     #print("tangent:")
@@ -676,36 +674,9 @@ def writeSPMFile(filename, objects=[]):
                     if need_export_tangent and uv_one:
                         print("Missing a triangle from loop map")
                     t1.m_tangent = [(0.0, 0.0, 0.0, 1.0), (0.0, 0.0, 0.0, 1.0), (0.0, 0.0, 0.0, 1.0)]
-                all_triangles.append(t1)
             else:
-                for t in [0, 1, 2]:
-                    t1.m_position.append(vertex_list[t][0])
-                    t1.m_normal.append(vertex_list[t][1])
-                    t1.m_color.append(vertex_list[t][2])
-                    t1.m_all_uvs.append(vertex_list[t][3])
-                    t1.m_all_joints_weights.append(vertex_list[t][4])
-                t1.m_texture_one = texture_one
-                t1.m_texture_two = texture_two
-                t1.m_texture_cmp = texture_cmp
-                t1.m_armature_name = arm.data.name if arm != None else "NULL"
-                t1.setHashString()
                 t1.m_tangent = [(0.0, 0.0, 0.0, 1.0), (0.0, 0.0, 0.0, 1.0), (0.0, 0.0, 0.0, 1.0)]
-                all_triangles.append(t1)
-                if (len(vertex_list) != 3):
-                    t2 = Triangle()
-                    for t in [0, 2, 3]:
-                        t2.m_position.append(vertex_list[t][0])
-                        t2.m_normal.append(vertex_list[t][1])
-                        t2.m_color.append(vertex_list[t][2])
-                        t2.m_all_uvs.append(vertex_list[t][3])
-                        t2.m_all_joints_weights.append(vertex_list[t][4])
-                    t2.m_texture_one = texture_one
-                    t2.m_texture_two = texture_two
-                    t2.m_texture_cmp = texture_cmp
-                    t2.m_armature_name = arm.data.name if arm != None else "NULL"
-                    t2.setHashString()
-                    t2.m_tangent = [(0.0, 0.0, 0.0, 1.0), (0.0, 0.0, 0.0, 1.0), (0.0, 0.0, 0.0, 1.0)]
-                    all_triangles.append(t2)
+            all_triangles.append(t1)
 
         if need_export_tangent:
             mesh.free_tangents()

--- a/io_antractica_scene/spm_export.py
+++ b/io_antractica_scene/spm_export.py
@@ -322,7 +322,7 @@ class ExportArm:
             unique_frame = getUniqueFrame(self.m_arm)
             if unique_frame is None:
                 return None
-            
+
             tmp_buf += writeUint16(len(unique_frame))
             for frame in unique_frame:
                 bpy.context.scene.frame_set(frame)
@@ -591,7 +591,7 @@ def writeSPMFile(filename, objects=[]):
             else:
                 uv_one = False
                 uv_two = False
-        
+
         print("UV layers to export:", uv_one, uv_two)
 
         # Smooth tangents ourselves
@@ -750,7 +750,7 @@ def writeSPMFile(filename, objects=[]):
                     t2.m_tangent = [(0.0, 0.0, 0.0, 1.0), (0.0, 0.0, 0.0, 1.0), (0.0, 0.0, 0.0, 1.0)]
                     all_triangles.append(t2)
 
-        if need_export_tangent: 
+        if need_export_tangent:
             mesh.free_tangents()
     if need_export_tangent and all_no_uv_one:
         print('{} (one of the object in the list) have no uvmap'.format(exp_obj[0].name))

--- a/io_antractica_scene/spm_export.py
+++ b/io_antractica_scene/spm_export.py
@@ -573,9 +573,11 @@ def writeSPMFile(filename, objects=[]):
 
         uv_one = mesh.uv_layers[0] if (len(mesh.uv_layers) >= 1) else None
         uv_two = mesh.uv_layers[1] if (len(mesh.uv_layers) >= 2) else None
-        colors = mesh.vertex_colors[0] if (len(mesh.vertex_colors) >= 1) else None
-
         print("UV layers to export:", uv_one, uv_two)
+
+        colors = mesh.vertex_colors[0] if (len(mesh.vertex_colors) >= 1) else None
+        if colors:
+            has_vertex_color = True
 
         mesh.calc_loop_triangles()
 
@@ -645,8 +647,6 @@ def writeSPMFile(filename, objects=[]):
 
                 vertex_color = [255, 255, 255]
                 if colors:
-                    if has_vertex_color == False:
-                        has_vertex_color = True
                     vcolor = colors.data[li].color[:3]
                     vertex_color = [min(int(c * 255), 255) for c in vcolor]
 

--- a/io_antractica_scene/spm_export.py
+++ b/io_antractica_scene/spm_export.py
@@ -512,7 +512,6 @@ def writeSPMFile(filename, objects=[]):
 
     has_vertex_color = False
     # TODO replace by parameters from the exporter
-    use_blender_materials = False
     need_export_tangent = spm_parameters.get("export-tangent")
     arm_count = 0
     arm_dict = {}
@@ -857,7 +856,6 @@ class SPM_Export_Operator(bpy.types.Operator):
     export_vcolor = bpy.props.BoolProperty(name="Export vertex color in mesh", default = True)
     export_tangent = bpy.props.BoolProperty(name="Calculate tangent and bitangent sign for mesh", default = True)
     static_mesh_frame = bpy.props.IntProperty(name="Frame for static mesh usage", default = -1)
-    use_blender_materials = bpy.props.BoolProperty(name="Export material instead of textures", default = False)
 
     def invoke(self, context, event):
         blend_filepath = context.blend_data.filepath
@@ -882,7 +880,6 @@ class SPM_Export_Operator(bpy.types.Operator):
         spm_parameters["export-vcolor"] = self.export_vcolor
         spm_parameters["export-tangent"] = self.export_tangent
         spm_parameters["static-mesh-frame"] = self.static_mesh_frame
-        spm_parameters["use-blender-materials"] = self.use_blender_materials
         spm_parameters["do-sp"] = self.do_sp
         the_scene = context.scene
 

--- a/io_antractica_scene/spm_export.py
+++ b/io_antractica_scene/spm_export.py
@@ -594,7 +594,12 @@ def writeSPMFile(filename, objects=[]):
                 tangents_triangles_dict[poly_tri] = poly_tri.m_tangent
 
         for i, f in enumerate(mesh.loop_triangles):
-            texture_one = obj.material_slots[f.material_index].name
+            if f.material_index < 0 or not obj.material_slots:
+                texture_one = ""
+            elif f.material_index < len(obj.material_slots):
+                texture_one = obj.material_slots[f.material_index].name
+            else:
+                texture_one = obj.material_slots[-1].name
             # We don't need to store the texture_two slot name (provided in material.xml)
             # If we have a second UV layer we put a fake texture
             texture_two = "FAKE_UV2" if uv_two else ""

--- a/io_antractica_scene/spm_export.py
+++ b/io_antractica_scene/spm_export.py
@@ -840,10 +840,20 @@ class SPM_Confirm_Operator(bpy.types.Operator):
         return {'FINISHED'}
 
 # ==== EXPORT OPERATOR ====
+from bpy_extras.io_utils import ExportHelper
 
-class SPM_Export_Operator(bpy.types.Operator):
+class SPM_Export_Operator(bpy.types.Operator, ExportHelper):
+    """"Save a SPM File"""
+
     bl_idname = ("screen.spm_export")
-    bl_label = ("SPM Export")
+    bl_label = ("Export SPM")
+    bl_option = {'PRESET'}
+
+    filename_ext = ".spm"
+    filter_glob: bpy.props.StringProperty(
+        default="*.spm",
+        options={'HIDDEN'},
+    )
 
     filepath = bpy.props.StringProperty(subtype="FILE_PATH")
     selected = bpy.props.BoolProperty(name="Export selected only", default = False)
@@ -856,17 +866,6 @@ class SPM_Export_Operator(bpy.types.Operator):
     export_vcolor = bpy.props.BoolProperty(name="Export vertex color in mesh", default = True)
     export_tangent = bpy.props.BoolProperty(name="Calculate tangent and bitangent sign for mesh", default = True)
     static_mesh_frame = bpy.props.IntProperty(name="Frame for static mesh usage", default = -1)
-
-    def invoke(self, context, event):
-        blend_filepath = context.blend_data.filepath
-        if not blend_filepath:
-            blend_filepath = "Untitled.spm"
-        else:
-            blend_filepath = os.path.splitext(blend_filepath)[0] + ".spm"
-        self.filepath = blend_filepath
-
-        context.window_manager.fileselect_add(self)
-        return {'RUNNING_MODAL'}
 
     def execute(self, context):
 
@@ -885,9 +884,6 @@ class SPM_Export_Operator(bpy.types.Operator):
 
         if self.filepath == "":
             return {'FINISHED'}
-
-        if not self.filepath.endswith(".spm"):
-            self.filepath += ".spm"
 
         print("EXPORT", self.filepath)
 

--- a/io_antractica_scene/spm_export.py
+++ b/io_antractica_scene/spm_export.py
@@ -914,12 +914,22 @@ def menu_func_export(self, context):
     the_scene = context.scene
     self.layout.operator(SPM_Export_Operator.bl_idname, text="SPM (.spm)")
 
+classes = (
+    SPM_Confirm_Operator,
+    SPM_Export_Operator,
+)
+
 def register():
-    bpy.utils.register_class(SPM_Export_Operator)
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
     bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
 
 def unregister():
     bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
 
+    for cls in classes:
+        bpy.utils.unregister_class(cls)
+
 if __name__ == "__main__":
-    register
+    register()

--- a/io_antractica_scene/spm_import.py
+++ b/io_antractica_scene/spm_import.py
@@ -45,10 +45,7 @@ from bpy_extras.image_utils import load_image
 spm_version = 1
 
 def create_material(tex_fname_1, tex_fname_2, tex_name_1, tex_name_2):
-    material_name =\
-        (tex_name_1 if tex_name_1 else "_") +\
-        "_" +\
-        (tex_name_2 if tex_name_2 else "_")
+    material_name = (tex_name_1 if tex_name_1 else "_")
     material = bpy.data.materials.new(material_name)
 
     # TODO: overlay tex_fname_2 on top of tex_fname_1


### PR DESCRIPTION
You can read the individual commits, but in summary

* fixes up the exporter so it works in Blender 2.80
* deletes the use_blender_materials options: the exporter now behaves as though it were always on (because the old texture system is gone in 2.8)
* some tweaks to make the export operator more consistent with the other exporters; also fixes some small bugs (when registering classes, when overwriting existing files, when running the file from the text editor)
* changes the importer to use the name of the first texture as the material name, because that is what the exporter expected when using the use_blender_materials option. This makes round-tripping work.

I only tested with one model, and only tested round-tripping in Blender, not how it works in TuxKart or anything, but this should get you started.