### PR TITLE
Fix api bug in export_spm.py

### DIFF
--- a/io_scene_spm/export_spm.py
+++ b/io_scene_spm/export_spm.py
@@ -482,7 +482,7 @@ def writeSPMFile(filename, spm_parameters={}):
     if spm_parameters.get("selection-type") == "selected":
         exp_obj = bpy.context.selected_objects
     elif spm_parameters.get("selection-type") == "scene":
-        exp_obj = bpy.scene.objects
+        exp_obj = bpy.data.objects
     elif spm_parameters.get("selection-type") == "view-layer":
         exp_obj = bpy.view_layer.objects
     else:


### PR DESCRIPTION
Fixed blender spm export error: AttributeError: module 'bpy' has no attribute 'scene'